### PR TITLE
Add support for tagging items in download.yaml & downloading subsets

### DIFF
--- a/example/download.yaml
+++ b/example/download.yaml
@@ -10,4 +10,5 @@
   index: chembl_28_molecule
 -
   url: gs://monarch-ingest/merged_graph_stats.yaml
+  tag: graph_stats
 

--- a/kghub_downloader/download_utils.py
+++ b/kghub_downloader/download_utils.py
@@ -14,17 +14,19 @@ from compress_json import compress_json
 from tqdm.auto import tqdm  # type: ignore
 from google.cloud import storage
 from google.cloud.storage.blob import Blob
-from urllib.parse import urlparse
+from typing import List
+
 
 def download_from_yaml(yaml_file: str, output_dir: str,
-                       ignore_cache: bool = False) -> None:
+                       ignore_cache: bool = False,
+                       tags: List = None) -> None:
     """Given an download info from an download.yaml file, download all files
 
     Args:
         yaml_file: A string pointing to the download.yaml file, to be parsed for things to download.
         output_dir: A string pointing to where to write out downloaded files.
         ignore_cache: Ignore cache and download files even if they exist [false]
-
+        tags: Limit to only downloads with this tag
     Returns:
         None.
     """
@@ -33,6 +35,11 @@ def download_from_yaml(yaml_file: str, output_dir: str,
     with open(yaml_file) as f:
         data = yaml.load(f, Loader=yaml.FullLoader)
         for item in tqdm(data, desc="Downloading files"):
+            if tags:
+                if "tag" not in item or not item["tag"] or item["tag"] not in tags:
+                    logging.warning("Skipping {} ".format(item))
+                    continue
+
             if 'url' not in item:
                 logging.warning("Couldn't find url for source in {}".format(item))
                 continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kghub-downloader"
-version = "0.1.5"
+version = "0.1.6"
 description = "Downloads and caches files for knowledge graph ETL"
 authors = ["The Monarch Initiative <info@monarchinitiative.org>"]
 

--- a/test/test_download.py
+++ b/test/test_download.py
@@ -2,6 +2,7 @@ from kghub_downloader.download_utils import download_from_yaml
 from os.path import exists
 import os
 
+
 # Integration test using example configuration
 def test_download():
     files = ["output/fish_phenotype.txt", "output/molecule.json", "output/merged_graph_stats.yaml"]
@@ -16,3 +17,23 @@ def test_download():
         assert exists(file)
         assert os.stat(file).st_size > 0
 
+
+def test_tag():
+    files = ["output/fish_phenotype.txt", "output/molecule.json", "output/merged_graph_stats.yaml"]
+    tagged_files = ["output/merged_graph_stats.yaml"]
+
+    for file in files:
+        if exists(file):
+            os.remove(file)
+
+    download_from_yaml(yaml_file="example/download.yaml",
+                       output_dir="output",
+                       tags=['graph_stats'])
+
+    for file in tagged_files:
+        assert exists(file)
+        assert os.stat(file).st_size > 0
+
+    for file in files:
+        if file not in tagged_files:
+            assert not exists(file)


### PR DESCRIPTION
My goal with this is to give monarch-ingest support for downloading only the files necessary for a given ingest, but rather than use "ingest" as the field I thought it made more sense to generalize it to tag. 