### PR TITLE
Fix use of --tag to download subsets

### DIFF
--- a/kghub_downloader/main.py
+++ b/kghub_downloader/main.py
@@ -14,7 +14,11 @@ def main(
          tag: Optional[List[str]] = typer.Option(None, help="Optional list of tags to limit downloading to"),
          mirror: Optional[str] = typer.Option(None, help="Optional remote storage URL to mirror download to. Supported buckets: Google Cloud Storage")
          ):
-    download_from_yaml(yaml_file, output_dir, ignore_cache, tag, mirror)
+    download_from_yaml(yaml_file=yaml_file,
+                       output_dir=output_dir,
+                       ignore_cache=ignore_cache,
+                       tags=tag,
+                       mirror=mirror)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kghub-downloader"
-version = "0.3.1"
+version = "0.3.2"
 description = "Downloads and caches files for knowledge graph ETL"
 authors = ["The Monarch Initiative <info@monarchinitiative.org>"]
 


### PR DESCRIPTION
There was a missing param, so tag arguments ended up looking like snippet=True.
