### PR TITLE
Enable Github Release Asset download

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,7 @@ Available options are:
   - Google Cloud Storage (`gs://`)
   - Google Drive (`gdrive://` or https://drive.google.com/...). The file must be publicly accessible.
   - Amazon AWS S3 bucket (`s3://`)
+  - GitHub Release Assets (`git://RepositoryOwner/RepositoryName`)
 - **local_name**: The name to save the file as locally
 - **tag**: A tag to use to filter downloads
 - **api**: The API to use to download the file. Currently supported: `elasticsearch`

--- a/example/download.yaml
+++ b/example/download.yaml
@@ -1,19 +1,23 @@
 ---
-- url: https://zfin.org/downloads/phenoGeneCleanData_fish.txt
-  local_name: zfin/fish_phenotype.txt
+# - url: https://zfin.org/downloads/phenoGeneCleanData_fish.txt
+#   local_name: zfin/fish_phenotype.txt
 
-- url: gs://monarch-test/kghub_downloader_test_file.yaml
-  local_name: test_file.yaml
+# - url: gs://monarch-test/kghub_downloader_test_file.yaml
+#   local_name: test_file.yaml
 
-- url: gdrive:10ojJffrPSl12OMcu4gyx0fak2CNu6qOs
-  local_name: gdrive_test_1.txt
-  tag: testing
+# - url: gdrive:10ojJffrPSl12OMcu4gyx0fak2CNu6qOs
+#   local_name: gdrive_test_1.txt
+#   tag: testing
 
-- url: https://drive.google.com/uc?id=10ojJffrPSl12OMcu4gyx0fak2CNu6qOs
-  local_name: gdrive_test_2.txt
+# - url: https://drive.google.com/uc?id=10ojJffrPSl12OMcu4gyx0fak2CNu6qOs
+#   local_name: gdrive_test_2.txt
 
-- url: s3://monarch-kg-test/kghub_downloader_test_file.yaml
-  local_name: test_file.yaml
+# - url: s3://monarch-kg-test/kghub_downloader_test_file.yaml
+#   local_name: test_file.yaml
+
+- url: git://Knowledge-Graph-Hub/kg-microbe/testfile.zip
+  tag: v0.0.1
+  local_name: testfile.zip
 
 # - url: https://www.ebi.ac.uk/chembl/elk/es/
 #   api: elasticsearch

--- a/example/download.yaml
+++ b/example/download.yaml
@@ -1,19 +1,19 @@
 ---
-# - url: https://zfin.org/downloads/phenoGeneCleanData_fish.txt
-#   local_name: zfin/fish_phenotype.txt
+- url: https://zfin.org/downloads/phenoGeneCleanData_fish.txt
+  local_name: zfin/fish_phenotype.txt
 
-# - url: gs://monarch-test/kghub_downloader_test_file.yaml
-#   local_name: test_file.yaml
+- url: gs://monarch-test/kghub_downloader_test_file.yaml
+  local_name: test_file.yaml
 
-# - url: gdrive:10ojJffrPSl12OMcu4gyx0fak2CNu6qOs
-#   local_name: gdrive_test_1.txt
-#   tag: testing
+- url: gdrive:10ojJffrPSl12OMcu4gyx0fak2CNu6qOs
+  local_name: gdrive_test_1.txt
+  tag: testing
 
-# - url: https://drive.google.com/uc?id=10ojJffrPSl12OMcu4gyx0fak2CNu6qOs
-#   local_name: gdrive_test_2.txt
+- url: https://drive.google.com/uc?id=10ojJffrPSl12OMcu4gyx0fak2CNu6qOs
+  local_name: gdrive_test_2.txt
 
-# - url: s3://monarch-kg-test/kghub_downloader_test_file.yaml
-#   local_name: test_file.yaml
+- url: s3://monarch-kg-test/kghub_downloader_test_file.yaml
+  local_name: test_file.yaml
 
 - url: git://Knowledge-Graph-Hub/kg-microbe/testfile.zip
   tag: v0.0.1

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -7,10 +7,11 @@ from kghub_downloader.download_utils import download_from_yaml
 # Integration test using example configuration
 def test_download():
     files = files = [
-        "test/output/zfin/fish_phenotype.txt",
-        "test/output/test_file.yaml",
-        "test/output/gdrive_test_1.txt",
-        "test/output/gdrive_test_2.txt",
+        # "test/output/zfin/fish_phenotype.txt",
+        # "test/output/test_file.yaml",
+        # "test/output/gdrive_test_1.txt",
+        # "test/output/gdrive_test_2.txt",
+        "test/output/testfile.zip",
     ]
 
     for file in files:

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -7,10 +7,10 @@ from kghub_downloader.download_utils import download_from_yaml
 # Integration test using example configuration
 def test_download():
     files = files = [
-        # "test/output/zfin/fish_phenotype.txt",
-        # "test/output/test_file.yaml",
-        # "test/output/gdrive_test_1.txt",
-        # "test/output/gdrive_test_2.txt",
+        "test/output/zfin/fish_phenotype.txt",
+        "test/output/test_file.yaml",
+        "test/output/gdrive_test_1.txt",
+        "test/output/gdrive_test_2.txt",
         "test/output/testfile.zip",
     ]
 


### PR DESCRIPTION
The `download.yaml` entry for this download looks like

```yaml
- url: git://RepositoryOwner/RepositoryName/asset_name.zip
  tag: v0.0.1
  local_name: testfile.zip
```

In the absence of the `tag` value, it'll go and download the latest release that has the asset.