### PR TITLE
Add individual download progress

### DIFF
--- a/kghub_downloader/download.py
+++ b/kghub_downloader/download.py
@@ -84,8 +84,7 @@ def google_cloud_storage(item: DownloadableResource, outfile_path: Path, snippet
 def google_drive(item: DownloadableResource, outfile_path: Path, snippet_only: bool) -> None:
     """Download from Google Drive."""
     url = item.expanded_url
-    if url.startswith("gdrive:"):
-        url = GOOGLE_DRIVE_PREFIX + url[7:]
+    url = GOOGLE_DRIVE_PREFIX + url[7:]
     gdown.download(url, output=str(outfile_path))
 
 
@@ -194,7 +193,8 @@ def http(item: DownloadableResource, outfile_path: Path, snippet_only: bool) -> 
     url = item.expanded_url
 
     if url.startswith(GOOGLE_DRIVE_PREFIX):
-        return google_drive(item, outfile_path, snippet_only)
+        gdown.download(url, output=str(outfile_path))
+        return
 
     response = requests.get(url, headers={"User-Agent": "Mozilla/5.0"}, stream=True, timeout=10)
 

--- a/kghub_downloader/download.py
+++ b/kghub_downloader/download.py
@@ -101,7 +101,7 @@ def s3(item: DownloadableResource, outfile_path: Path, snippet_only: bool) -> No
     object_size = s3_object.content_length
 
     with open_with_write_progress(item, outfile_path, object_size) as outfile:
-        s3.object.download_fileobj(outfile)
+        s3_object.download_fileobj(outfile)
 
 
 @register_scheme("ftp")

--- a/kghub_downloader/download.py
+++ b/kghub_downloader/download.py
@@ -197,6 +197,7 @@ def http(item: DownloadableResource, outfile_path: Path, snippet_only: bool) -> 
         return
 
     response = requests.get(url, headers={"User-Agent": "Mozilla/5.0"}, stream=True, timeout=10)
+    response.raise_for_status()
 
     size = int(response.headers.get("Content-Length", 0))
     if snippet_only and size > SNIPPET_SIZE:

--- a/kghub_downloader/download.py
+++ b/kghub_downloader/download.py
@@ -93,7 +93,7 @@ def google_drive(item: DownloadableResource, outfile_path: Path, snippet_only: b
 def s3(item: DownloadableResource, outfile_path: Path, snippet_only: bool) -> None:
     """Download from S3 bucket."""
     url = item.expanded_url
-    s3 = boto3.client("s3")
+    s3 = boto3.resource("s3")
     bucket_name = url.split("/")[2]
     remote_file = "/".join(url.split("/")[3:])
 

--- a/kghub_downloader/main.py
+++ b/kghub_downloader/main.py
@@ -14,6 +14,7 @@ def main(
     yaml_file: Optional[str] = typer.Argument("download.yaml", help="List of files to download in YAML format"),
     output_dir: Optional[str] = typer.Option(".", help="Path to output directory"),
     ignore_cache: Optional[bool] = typer.Option(False, help="Ignoring already downloaded files and download again"),
+    verbose: Optional[bool] = typer.Option(False, help="Show verbose output"),
     tags: Optional[List[str]] = typer.Option(None, help="Optional list of tags to limit downloading to"),  # noqa: B008
     mirror: Optional[str] = typer.Option(
         None,
@@ -25,6 +26,7 @@ def main(
         yaml_file=yaml_file,
         output_dir=output_dir,
         ignore_cache=ignore_cache,
+        verbose=verbose,
         tags=tags,
         mirror=mirror,
     )

--- a/kghub_downloader/main.py
+++ b/kghub_downloader/main.py
@@ -1,32 +1,67 @@
 """CLI interface for kghub-downloader."""
 
-from typing import List, Optional
+from typing import Annotated, List, Optional
 
 import typer
 
 from kghub_downloader.download_utils import download_from_yaml
+from kghub_downloader.model import DownloadOptions
 
 typer_app = typer.Typer()
 
 
 @typer_app.command()
 def main(
-    yaml_file: Optional[str] = typer.Argument("download.yaml", help="List of files to download in YAML format"),
-    output_dir: Optional[str] = typer.Option(".", help="Path to output directory"),
-    ignore_cache: Optional[bool] = typer.Option(False, help="Ignoring already downloaded files and download again"),
-    verbose: Optional[bool] = typer.Option(False, help="Show verbose output"),
-    tags: Optional[List[str]] = typer.Option(None, help="Optional list of tags to limit downloading to"),  # noqa: B008
-    mirror: Optional[str] = typer.Option(
-        None,
-        help="Optional remote storage URL to mirror download to. Supported buckets: Google Cloud Storage",
-    ),
+    yaml_file: Annotated[
+        str,
+        typer.Argument(help="List of files to download in YAML format"),
+    ] = "download.yaml",
+    output_dir: Annotated[
+        str,
+        typer.Option(help="Path to output directory"),
+    ] = ".",
+    ignore_cache: Annotated[
+        bool,
+        typer.Option(help="Ignoring already downloaded files and download again"),
+    ] = False,
+    progress: Annotated[
+        bool,
+        typer.Option(help="Show progress for individual downloads"),
+    ] = False,
+    fail_on_error: Annotated[
+        bool,
+        typer.Option(help="Do not attempt to download more files if one raises an error"),
+    ] = True,
+    snippet_only: Annotated[
+        bool,
+        typer.Option(help="Only download a snippet of the file. [HTTP(S) resources only.")
+    ] = False,
+    verbose: Annotated[
+        bool,
+        typer.Option(help="Show verbose output"),
+    ] = False,
+    tags: Annotated[
+        Optional[List[str]],
+        typer.Option(help="Optional list of tags to limit downloading to"),
+    ] = None,
+    mirror: Annotated[
+        Optional[str],
+        typer.Option(help="Optional remote storage URL to mirror download to. Supported buckets: Google Cloud Storage"),
+    ] = None,
 ):
     """Download a set of files defined in a YAML file."""
+    options = DownloadOptions(
+        snippet_only=snippet_only,
+        ignore_cache=ignore_cache,
+        progress=progress,
+        fail_on_error=fail_on_error,
+        verbose=verbose,
+    )
+
     download_from_yaml(
         yaml_file=yaml_file,
         output_dir=output_dir,
-        ignore_cache=ignore_cache,
-        verbose=verbose,
+        download_options=options,
         tags=tags,
         mirror=mirror,
     )

--- a/kghub_downloader/main.py
+++ b/kghub_downloader/main.py
@@ -27,11 +27,11 @@ def main(
     progress: Annotated[
         bool,
         typer.Option(help="Show progress for individual downloads"),
-    ] = False,
+    ] = True,
     fail_on_error: Annotated[
         bool,
         typer.Option(help="Do not attempt to download more files if one raises an error"),
-    ] = True,
+    ] = False,
     snippet_only: Annotated[
         bool,
         typer.Option(help="Only download a snippet of the file. [HTTP(S) resources only.")

--- a/kghub_downloader/model.py
+++ b/kghub_downloader/model.py
@@ -17,6 +17,16 @@ valid_url_schemes = [
 ]
 
 
+class DownloadOptions(BaseModel):
+    """Options for downloading a resource."""
+
+    snippet_only: bool = False
+    ignore_cache: bool = False
+    progress: bool = False
+    fail_on_error: bool = True
+    verbose: bool = False
+
+
 class DownloadableResource(BaseModel):
     """A resource able to be downloaded."""
 

--- a/kghub_downloader/schemes.py
+++ b/kghub_downloader/schemes.py
@@ -4,9 +4,9 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Dict, Optional
 
-from kghub_downloader.model import DownloadableResource
+from kghub_downloader.model import DownloadableResource, DownloadOptions
 
-ResourceDownloadFunction = Callable[[DownloadableResource, Path, bool], None]
+ResourceDownloadFunction = Callable[[DownloadableResource, Path, DownloadOptions], None]
 
 ResourceDownloadRegistry = Dict[str, ResourceDownloadFunction]
 

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -7,6 +7,7 @@ import pytest
 
 from kghub_downloader import download, model
 from kghub_downloader.download_utils import download_from_yaml
+from kghub_downloader.model import DownloadOptions
 
 # ruff: noqa: D100, D101, D102
 
@@ -35,32 +36,32 @@ class TestDownload(unittest.TestCase):
     def test_http(self):
         resource = model.DownloadableResource(url="https://zfin.org/downloads/phenoGeneCleanData_fish.txt")
         output_file = output_files["https"]
-        download.http(resource, output_file, False)
+        download.http(resource, output_file, DownloadOptions())
         self._assert_file_exists(output_file)
 
     def test_google_cloud_storage(self):
         resource = model.DownloadableResource(url="gs://monarch-test/kghub_downloader_test_file.yaml")
         output_file = output_files["google_cloud_storage"]
-        download.google_cloud_storage(resource, output_file, False)
+        download.google_cloud_storage(resource, output_file, DownloadOptions())
         self._assert_file_exists(output_file)
 
     def test_google_drive(self):
         resource = model.DownloadableResource(url="gdrive:10ojJffrPSl12OMcu4gyx0fak2CNu6qOs")
         output_file = output_files["google_drive_1"]
-        download.google_drive(resource, output_file, False)
+        download.google_drive(resource, output_file, DownloadOptions())
         self._assert_file_exists(output_file)
 
     @pytest.mark.usefixtures('mock_s3_test_file')
     def test_s3(self):
         resource = model.DownloadableResource(url="s3://monarch-test/kghub_downloader_test_file.yaml")
         output_file = output_files["s3"]
-        download.s3(resource, output_file, False)
+        download.s3(resource, output_file, DownloadOptions())
         self._assert_file_exists(output_file)
 
     def test_git(self):
         resource = model.DownloadableResource(url="git://Knowledge-Graph-Hub/kg-microbe/testfile.zip")
         output_file = output_files["git"]
-        download.git(resource, output_file, False)
+        download.git(resource, output_file, DownloadOptions())
         self._assert_file_exists(output_file)
 
     @pytest.mark.usefixtures('mock_s3_test_file')

--- a/test/unit/test_register_schema.py
+++ b/test/unit/test_register_schema.py
@@ -9,7 +9,8 @@ class TestSchemeRegister(unittest.TestCase):
         registry = {}
 
         @schemes.register_scheme("ex", registry)
-        def downloader(item: model.DownloadableResource, path: Path, snippet_only: bool) -> None:
+        def downloader(item: model.DownloadableResource, path: Path,
+                       download_options: model.DownloadOptions) -> None:
             return
 
         self.assertEqual(list(registry.keys()), ["ex"])


### PR DESCRIPTION
This PR makes a few major changes:

1. There are now progress bars for individual downloads. They look like this: ![image](https://github.com/user-attachments/assets/72b148d8-66d3-4a3f-8eef-241788ab71b5)

2. Instead of erroring out when a download runs into an error, the program will log that an error occurred and continue on. The error can be reported with a new `verbose` flag/parameter. The log above the current progress bars looks like this:
  ```
SKIPPING: ../monarch-ingest/data/string/10090.protein_links.txt.gz already exists
OK: Downloaded https://stringdb-downloads.org/download/protein.links.detailed.v12.0/9615.protein.links.detailed.v12.0.txt.gz                                                                                                               
SKIPPING: ../monarch-ingest/data/string/9913.protein_links.txt.gz already exists
SKIPPING: ../monarch-ingest/data/string/9031.protein_links.txt.gz already exists
ERROR: Failed to download gs://monarch-test/kghub_downloader_test_file.yaml
SKIPPING: ../monarch-ingest/data/xenbase/LiteratureMatchedGenesByPaper.txt already exists
SKIPPING: ../monarch-ingest/data/xenbase/xb_xpo_spo_v_v1.tab already exists
OK: Downloaded http://ftp.xenbase.org/pub/GenePageReports/XenbaseGeneHumanOrthologMapping.txt          
SKIPPING: ../monarch-ingest/data/xenbase/XenbaseGeneMouseOrthologMapping.txt already exists
  ```
3. The command generates a report at the end of the download showing some statistics:
```
Download completed in 14.12 seconds.  

    successful:   18
    skipped:      73
    unsuccessful: 2

Some downloads were unsuccessful. Run with --verbose to see errors
```